### PR TITLE
优化：预览图生成时清除所有EXIF数据

### DIFF
--- a/common/function_archive.py
+++ b/common/function_archive.py
@@ -65,7 +65,8 @@ def save_preview_image(archive: str, image_path_inside: str, preview_image_path:
     width, height = image.size
     resize_width = int(height_zoom_out * width / height)
     image = image.resize((resize_width, height_zoom_out), Image.LANCZOS)
-    # 保存到本地
+    # 清除清除所有元数据，保存到本地
+    image.info.clear()
     image.save(preview_image_path)
 
     return preview_image_path

--- a/common/function_file.py
+++ b/common/function_file.py
@@ -66,7 +66,8 @@ def save_preview_image(origin_image_path: str, preview_image_path: str, height_z
     width, height = image.size
     resize_width = int(height_zoom_out * width / height)
     image = image.resize((resize_width, height_zoom_out), Image.LANCZOS)
-    # 保存到本地
+    # 清除清除所有元数据，保存到本地
+    image.info.clear()
     image.save(preview_image_path)
 
     return preview_image_path


### PR DESCRIPTION
在`检查漫画在数据库中是否已存在`的步骤中，遭遇问题并返回以下信息：

```
Traceback (most recent call last):
  File "D:\temp1\trae_1\ComicDup\components\window\window_presenter.py", line 178, in thread_analyse_comic_info_finished
    self.model.save_comic_info_to_db(comic_info_dict.values())
  File "D:\temp1\trae_1\ComicDup\components\window\window_model.py", line 36, in save_comic_info_to_db
    comic_info.save_preview_image()  # 新增前保存预览图
  File "D:\temp1\trae_1\ComicDup\common\class_comic.py", line 141, in save_preview_image
    self.preview_path = function_cache_preview.save_preview_image_to_cache(first_image)
  File "D:\temp1\trae_1\ComicDup\common\function_cache_preview.py", line 56, in save_preview_image_to_cache
    save_path = function_file.save_preview_image(origin_image_path, preview_image_path, height_zoom_out)
  File "D:\temp1\trae_1\ComicDup\common\function_file.py", line 70, in save_preview_image
    image.save(preview_image_path)
  File "C:\Users\93222\AppData\Local\Programs\Python\Python310\lib\site-packages\PIL\Image.py", line 2605, in save    
    save_handler(self, fp, filename)
  File "C:\Users\93222\AppData\Local\Programs\Python\Python310\lib\site-packages\PIL\JpegImagePlugin.py", line 760, in _save
    raise ValueError(msg)
ValueError: XMP data is too long
```

经检查发现部分图片的XMP信息容量及其巨大且不符合 EXIF 规范，例如某图片中的XMP信息中包含 6,012,929 字节的数据。

ahash，phash，dhash中并不检查EXIF，从预览图中删除EXIF数据能极大节省存储空间，缩短缓存时间，预防EXIF数据不符合规范导致的问题。